### PR TITLE
Added lastnonwhite functionality and mapping

### DIFF
--- a/autoload/JumpToVerticalOccurrence.vim
+++ b/autoload/JumpToVerticalOccurrence.vim
@@ -116,7 +116,7 @@ function! s:Jump( target, mode, directionFlag )
     endif
 
 	let l:virtCol = virtcol('.')
-	if a:target ==# 'cursor' || a:target ==# 'lastsame'
+	if a:target ==# 'cursor' || a:target ==# 'lastsame'|| a:target ==# 'lastnonewhite'
 	    let l:char = ingo#text#GetChar(getpos('.')[1:2])
 	endif
 
@@ -135,6 +135,8 @@ function! s:Jump( target, mode, directionFlag )
 
     if a:target ==# 'lastsame'
 	return s:LastSameJump(l:virtCol, l:pattern, l:count, a:directionFlag, a:mode)
+    elseif a:target ==# 'lastnonewhite'
+	return s:LastSameJump(l:virtCol, '\S', l:count, a:directionFlag, a:mode)
     else
 	let l:columnCharPattern = printf('\C\V\%%%dv%s', l:virtCol, l:pattern)
 	return CountJump#CountJump(a:mode, l:columnCharPattern, a:directionFlag . 'W')
@@ -177,6 +179,13 @@ function! JumpToVerticalOccurrence#LastSameCharForward( mode )
 endfunction
 function! JumpToVerticalOccurrence#LastSameCharBackward( mode )
     return s:Jump('lastsame', a:mode, 'b')
+endfunction
+
+function! JumpToVerticalOccurrence#LastNonWhitespaceForward( mode )
+    return s:Jump('lastnonewhite', a:mode, '')
+endfunction
+function! JumpToVerticalOccurrence#LastNonWhitespaceBackward( mode )
+    return s:Jump('lastnonewhite', a:mode, 'b')
 endfunction
 
 " vim: set ts=8 sts=4 sw=4 noexpandtab ff=unix fdm=syntax :

--- a/plugin/JumpToVerticalOccurrence.vim
+++ b/plugin/JumpToVerticalOccurrence.vim
@@ -48,7 +48,9 @@ endif
 if ! exists('g:JumpToVerticalOccurrence_LastSameCharMapping')
     let g:JumpToVerticalOccurrence_LastSameCharMapping = '!'
 endif
-
+if ! exists('g:JumpToVerticalOccurrence_LastNonWhitespaceMapping')
+    let g:JumpToVerticalOccurrence_LastNonWhitespaceMapping = 'w'
+endif
 
 "- mappings --------------------------------------------------------------------
 
@@ -81,6 +83,12 @@ call CountJump#Motion#MakeBracketMotionWithJumpFunctions(
 \   '', g:JumpToVerticalOccurrence_LastSameCharMapping, '',
 \   function('JumpToVerticalOccurrence#LastSameCharForward'),
 \   function('JumpToVerticalOccurrence#LastSameCharBackward'),
+\   '', '', 0
+\)
+call CountJump#Motion#MakeBracketMotionWithJumpFunctions(
+\   '', g:JumpToVerticalOccurrence_LastNonWhitespaceMapping, '',
+\   function('JumpToVerticalOccurrence#LastNonWhitespaceForward'),
+\   function('JumpToVerticalOccurrence#LastNonWhitespaceBackward'),
 \   '', '', 0
 \)
 


### PR DESCRIPTION
Suggestion to achieve the question asked in the thread (allows going to last non white character vertically):

https://stackoverflow.com/questions/20882722/move-to-the-next-row-which-has-non-white-space-character-in-the-same-column-in-v

Note, the accepted answer doesn't work in visual.
I thought this this should have been implemented in this package, but couldn't get it to work (only if character is the same using `]v` which in fact a special case of the desired function)


**Usecase** which wasn't possible before (note ]v needs same character):

Turning this:

    aaa
      1a
      2c
      3d
    eee

into this(appending brackets):

    aaa
      1)a
      2)c
      3)d
    eee

say the cursor is on "a". 
Go in block select mode, 
go down till the firs non white character (until d). 
Insert )

    ^v]wI)<ESC>

Note:
"w" was choose because of memonic nonWhite, but could be changed of course.
I have tested the code, but it might have to be tested further. In case this is accepted, I'd be happy to amend the documentation.